### PR TITLE
Update (or drop) the Docker image used by Flatpak job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -81,7 +81,6 @@ package:deb-pureos-byzantium:arm64:
 
 # For some reason including https://gitlab.gnome.org/GNOME/citemplates/raw/master/flatpak/flatpak_ci_initiative.yml fails with a network error (status code 500), therefore it's copied here
 .flatpak:
-  image: 'registry.gitlab.gnome.org/gnome/gnome-runtime-images/gnome:master'
   stage: 'package'
   interruptible: true
   timeout: 4h


### PR DESCRIPTION
Зображення gnome-runtime нещодавно перенесли на Quay. Це вже відображено в шаблоні.

Зверніть увагу, що цей MR був створений напівавтоматично. Якщо немає сенсу, сміливо закривайте його.